### PR TITLE
SRStateData.Decode() - Correct bounds check

### DIFF
--- a/egts/subrecord/sr_state_data.go
+++ b/egts/subrecord/sr_state_data.go
@@ -40,7 +40,7 @@ func (subr *SRStateData) Decode(b []byte) (err error) {
 	if subr.StateByte, err = buffer.ReadByte(); err != nil {
 		return fmt.Errorf("EGTS_SR_STATE_DATA; Error reading ST")
 	}
-	if subr.StateByte < 0 || subr.StateByte > 8 {
+	if subr.StateByte < 0 || subr.StateByte >= 8 {
 		return fmt.Errorf("EGTS_SR_STATE_DATA; Such ST does not exists")
 	}
 	subr.State = states[subr.StateByte]

--- a/egts/subrecord_test/sr_state_data_test.go
+++ b/egts/subrecord_test/sr_state_data_test.go
@@ -31,4 +31,12 @@ func TestSRStateDataDecoding(t *testing.T) {
 			t.Errorf("Have to be %s, but got %s", SRStateDataCheckIncome[i], hex.EncodeToString(hexed))
 		}
 	}
+
+	stateData := subrecord.SRStateData{}
+	if err := stateData.Decode([]byte{0}); err == nil {
+		t.Errorf("Error: expected error, but got nil")
+	}
+	if err := stateData.Decode([]byte{8}); err == nil {
+		t.Errorf("Error: expected error, but got nil")
+	}
 }


### PR DESCRIPTION
This fixes a bounds check and adds unit tests for this check.