### PR TITLE
bugfix endian

### DIFF
--- a/egts/subrecord/sr_liquid_lever_sensor.go
+++ b/egts/subrecord/sr_liquid_lever_sensor.go
@@ -51,7 +51,7 @@ func (subr *SRLiquidLevelSensor) Decode(b []byte) (err error) {
 	if _, err = buffer.Read(sb); err != nil {
 		return fmt.Errorf("EGTS_SR_LIQUID_LEVEL_SENSOR; Error reading LLSD")
 	}
-	subr.LiquidLevelSensorb = binary.LittleEndian.Uint32(sb)
+	subr.LiquidLevelSensorb = binary.BigEndian.Uint32(sb)
 
 	return nil
 }
@@ -73,7 +73,7 @@ func (subr *SRLiquidLevelSensor) Encode() (b []byte, err error) {
 		return nil, fmt.Errorf("EGTS_SR_LIQUID_LEVEL_SENSOR; Error writing MADDR")
 	}
 
-	if err = binary.Write(buffer, binary.LittleEndian, subr.LiquidLevelSensorb); err != nil {
+	if err = binary.Write(buffer, binary.BigEndian, subr.LiquidLevelSensorb); err != nil {
 		return nil, fmt.Errorf("EGTS_SR_LIQUID_LEVEL_SENSOR; Error writing LLSD")
 	}
 

--- a/egts/subrecord/sr_pos_data.go
+++ b/egts/subrecord/sr_pos_data.go
@@ -121,7 +121,7 @@ func (subr *SRPosData) Decode(b []byte) (err error) {
 	if _, err = buffer.Read(subr.OdometerBytes); err != nil {
 		return fmt.Errorf("EGTS_SR_POS_DATA; Error reading ODM")
 	}
-	subr.Odometer = int(binary.LittleEndian.Uint32(append([]byte{0}, subr.OdometerBytes...))) / 10
+	subr.Odometer = int(binary.BigEndian.Uint32(append([]byte{0}, subr.OdometerBytes...))) / 10
 	// DIN Digital Inputs
 	if subr.DigitalInputs, err = buffer.ReadByte(); err != nil {
 		return fmt.Errorf("EGTS_SR_POS_DATA; Error reading DIN")
@@ -137,7 +137,7 @@ func (subr *SRPosData) Decode(b []byte) (err error) {
 		if _, err = buffer.Read(subr.AltitudeBytes); err != nil {
 			return fmt.Errorf("EGTS_SR_POS_DATA; Error reading ALT")
 		}
-		subr.Altitude = binary.LittleEndian.Uint32(append(subr.AltitudeBytes, byte(0)))
+		subr.Altitude = binary.BigEndian.Uint32(append([]byte{0}, subr.AltitudeBytes...))
 	}
 
 	return nil


### PR DESCRIPTION
Hi! From the docs, page 26: 

А.4.2 Многобайтовые типы данных USHORT, UINT, ULONG, FLOAT и DOUBLE
используют порядок следования байт little - endian (младший байт вперед).
Байты, составляющие последовательность в типах STRING и BINARY,
интерпретируются как есть, т.е. обрабатываются в порядке их поступления.

page 55:
EGTS_SR_POS_DATA
ODM  (Odometer)                         М   BINARY   3
ALT    (Altitude)                             О   BINARY   3

page 69:
EGTS_SR_LIQUID_LEVEL_SENSOR
LLSD (Liquid Level Sensor Data) М   BINARY   4 ... 512

